### PR TITLE
a little tweak for stripping HTML tables

### DIFF
--- a/src/php/strings/strip_tags.js
+++ b/src/php/strings/strip_tags.js
@@ -31,6 +31,9 @@ module.exports = function strip_tags (input, allowed) { // eslint-disable-line c
   //   returns 6: '1 <br/> 1'
   //   example 7: strip_tags('1 <br/> 1', '<br><br/>')
   //   returns 7: '1 <br/> 1'
+  
+  // ensure tables have line-returns between rows and tabbed delmited TD's..
+  input = input.replace(/<\/td>/gi, "\t").replace(/<\/tr>/gi,"\n");
 
   // making sure the allowed arg is a string containing only tags in lowercase (<a><b><c>)
   allowed = (((allowed || '') + '').toLowerCase().match(/<[a-z][a-z0-9]*>/g) || []).join('')


### PR DESCRIPTION
### Description

In my web application, I'm trying to make a robust copy-to-clipboard function and found your strip tags function to be useful when preparing my clipboard's plain-text version of the subject matter.

It's nice when you copy an HTML table and get a pretty version in plain text 

(pretty version == every table row is on a separate line, and column values are tab delimited)
